### PR TITLE
feat: add Codex PreToolUse hook support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ Loading priority:
 
 `tkn hook install` registers in `~/.claude/settings.json` as a PreToolUse hook. `tkn hook run` reads the hook JSON from stdin, rewrites commands to `tkn auto -- <original command>`, and outputs a JSON response.
 
+Codex uses repo-local `.codex/config.toml` and `.codex/hooks.json`. `tkn hook run --codex` reads Codex PreToolUse JSON from stdin and blocks bare Bash commands with instructions to rerun through `tkn`, because Codex parses but does not currently support `updatedInput` rewrites for PreToolUse.
+
 ## Important Notes
 
 - Prefer built-in plugins in `plugins/` and do not rely on stale user overrides in `~/.tkn/tools/` when validating behavior.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Start with a health check:
 tkn doctor
 ```
 
-This verifies local `~/.tkn` storage, built-in plugin availability, Claude hook state, and Codex repo bootstrap state.
+This verifies local `~/.tkn` storage, built-in plugin availability, Claude hook state, and Codex repo hook state.
 
 ### Claude Code (machine-level hook)
 
@@ -94,19 +94,25 @@ To remove the hook:
 tkn hook uninstall
 ```
 
-### Codex (repo bootstrap, not a global hook)
+### Codex (repo-level hook)
 
-Codex support is repo-based rather than hook-based. `tkn` manages a Codex block inside the target repo's `AGENTS.md`:
+Codex support is repo-based. `tkn` manages a Codex hook configuration and a small instructions block inside the target repo:
 
 ```sh
 tkn setup codex --repo /path/to/repo
 ```
 
-This creates or updates a managed section that tells Codex to default to:
+This creates or updates:
+
+- `.codex/config.toml` with `features.codex_hooks = true`
+- `.codex/hooks.json` with a Bash `PreToolUse` hook that runs `tkn hook run --codex`
+- `AGENTS.md` with a managed section that tells Codex to default to:
 
 - `tkn auto -- <command>`
 - `tkn exec -- <command>` for deterministic captured output
 - `tkn pass -- <command>` for interactive, long-lived, or streaming commands
+
+Codex does not currently support rewriting `PreToolUse` command input, so the hook blocks bare Bash commands and asks Codex to rerun them through `tkn`.
 
 To verify that a repo still has the current managed block:
 
@@ -174,6 +180,7 @@ Each plugin defines flag transforms (adding `--no-pager`, removing `--color=alwa
 | `tkn doctor [claude\|codex\|all] [--json]` | Verify tkn, Claude, and Codex setup |
 | `tkn hook install` | Install the Claude Code hook directly |
 | `tkn hook uninstall` | Remove the Claude Code hook |
+| `tkn hook run --codex` | Run the Codex `PreToolUse` hook mode |
 
 ## Writing plugins
 

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -16,7 +16,11 @@ pub fn run(target: Option<AssistantTarget>, repo: Option<&Path>, json: bool) -> 
         render_human(&report);
     }
 
-    if report.has_failures() { 1 } else { 0 }
+    if report.has_failures() {
+        1
+    } else {
+        0
+    }
 }
 
 fn build_report(target: AssistantTarget, repo: Option<&Path>) -> DoctorReport {
@@ -57,7 +61,10 @@ fn doctor_core() -> TargetReport {
     }
 
     checks.push(check_dir_writable("logs directory", &storage.logs_dir()));
-    checks.push(check_dir_writable("plugins directory", &storage.tools_dir()));
+    checks.push(check_dir_writable(
+        "plugins directory",
+        &storage.tools_dir(),
+    ));
     checks.push(check_builtin_registry());
 
     TargetReport {
@@ -169,6 +176,9 @@ fn doctor_codex_for_repo(
         }
     };
 
+    checks.push(check_codex_config(&repo_path));
+    checks.push(check_codex_hook(&repo_path));
+
     let agents_path = repo_path.join("AGENTS.md");
     if !agents_path.exists() {
         checks.push(CheckResult::fail(
@@ -176,51 +186,42 @@ fn doctor_codex_for_repo(
             format!("{} does not exist", agents_path.display()),
             format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
         ));
-        return TargetReport {
-            target: "codex".to_string(),
-            checks,
-        };
-    }
-
-    let agents_content = match fs::read_to_string(&agents_path) {
-        Ok(content) => content,
-        Err(e) => {
-            checks.push(CheckResult::fail(
-                "AGENTS.md",
-                format!("failed to read {}: {e}", agents_path.display()),
-                format!("Check permissions for {}.", agents_path.display()),
+    } else if let Ok(agents_content) = fs::read_to_string(&agents_path) {
+        if integration::codex_block_matches_current(&agents_content) {
+            checks.push(CheckResult::pass(
+                "Codex managed block",
+                "managed tkn block is current",
             ));
-            return TargetReport {
-                target: "codex".to_string(),
-                checks,
-            };
+        } else {
+            checks.push(CheckResult::fail(
+                "Codex managed block",
+                "managed tkn block is missing or stale",
+                format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            ));
         }
-    };
 
-    if integration::codex_block_matches_current(&agents_content) {
-        checks.push(CheckResult::pass(
-            "Codex managed block",
-            "managed tkn block is current",
-        ));
+        let contradictory = integration::contradictory_codex_lines(&agents_content);
+        if contradictory.is_empty() {
+            checks.push(CheckResult::pass(
+                "Contradictory instructions",
+                "no obvious bare command examples found outside the managed block",
+            ));
+        } else {
+            checks.push(CheckResult::warn(
+                "Contradictory instructions",
+                format!(
+                    "found {} possible bare command examples",
+                    contradictory.len()
+                ),
+                "Review AGENTS.md and route assistant-facing shell examples through tkn.",
+            ));
+        }
     } else {
+        let err = fs::read_to_string(&agents_path).unwrap_err();
         checks.push(CheckResult::fail(
-            "Codex managed block",
-            "managed tkn block is missing or stale",
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
-        ));
-    }
-
-    let contradictory = integration::contradictory_codex_lines(&agents_content);
-    if contradictory.is_empty() {
-        checks.push(CheckResult::pass(
-            "Contradictory instructions",
-            "no obvious bare command examples found outside the managed block",
-        ));
-    } else {
-        checks.push(CheckResult::warn(
-            "Contradictory instructions",
-            format!("found {} possible bare command examples", contradictory.len()),
-            "Review AGENTS.md and route assistant-facing shell examples through tkn.",
+            "AGENTS.md",
+            format!("failed to read {}: {err}", agents_path.display()),
+            format!("Check permissions for {}.", agents_path.display()),
         ));
     }
 
@@ -228,6 +229,111 @@ fn doctor_codex_for_repo(
         target: "codex".to_string(),
         checks,
     }
+}
+
+fn check_codex_config(repo_path: &Path) -> CheckResult {
+    let config_path = hook::codex_config_path(repo_path);
+    if !config_path.exists() {
+        return CheckResult::fail(
+            "Codex hooks feature",
+            format!("{} does not exist", config_path.display()),
+            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+        );
+    }
+
+    let content = match fs::read_to_string(&config_path) {
+        Ok(content) => content,
+        Err(e) => {
+            return CheckResult::fail(
+                "Codex hooks feature",
+                format!("failed to read {}: {e}", config_path.display()),
+                format!("Check permissions for {}.", config_path.display()),
+            );
+        }
+    };
+
+    let value = match toml::from_str::<toml::Value>(&content) {
+        Ok(value) => value,
+        Err(e) => {
+            return CheckResult::fail(
+                "Codex hooks feature",
+                format!("invalid TOML in {}: {e}", config_path.display()),
+                format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            );
+        }
+    };
+
+    if value
+        .get("features")
+        .and_then(|features| features.get("codex_hooks"))
+        .and_then(|enabled| enabled.as_bool())
+        == Some(true)
+    {
+        CheckResult::pass("Codex hooks feature", "features.codex_hooks is enabled")
+    } else {
+        CheckResult::fail(
+            "Codex hooks feature",
+            "features.codex_hooks is not enabled",
+            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+        )
+    }
+}
+
+fn check_codex_hook(repo_path: &Path) -> CheckResult {
+    let hooks_path = hook::codex_hooks_path(repo_path);
+    if !hooks_path.exists() {
+        return CheckResult::fail(
+            "Codex PreToolUse hook",
+            format!("{} does not exist", hooks_path.display()),
+            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+        );
+    }
+
+    let settings = match hook::read_settings(&hooks_path) {
+        Ok(settings) => settings,
+        Err(e) => {
+            return CheckResult::fail(
+                "Codex PreToolUse hook",
+                e,
+                format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            );
+        }
+    };
+
+    let entries = hook::codex_hook_entries_for_matcher(&settings, hook::TKN_CODEX_MATCHER);
+    let tkn_entries: Vec<_> = entries
+        .into_iter()
+        .filter(|entry| hook::is_tkn_hook(entry))
+        .collect();
+
+    if tkn_entries.is_empty() {
+        return CheckResult::fail(
+            "Codex PreToolUse hook",
+            "missing tkn hook entry",
+            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+        );
+    }
+
+    if tkn_entries.len() > 1 {
+        return CheckResult::fail(
+            "Codex PreToolUse hook",
+            "duplicate tkn hook entries detected",
+            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+        );
+    }
+
+    if !hook::has_expected_codex_hook_command(tkn_entries[0]) {
+        return CheckResult::fail(
+            "Codex PreToolUse hook",
+            "tkn hook entry does not point to `tkn hook run --codex`",
+            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+        );
+    }
+
+    CheckResult::pass(
+        "Codex PreToolUse hook",
+        "configured with `tkn hook run --codex`",
+    )
 }
 
 fn check_claude_matcher(settings: &serde_json::Value, matcher: &str) -> CheckResult {
@@ -311,7 +417,10 @@ fn check_builtin_registry() -> CheckResult {
         }
     }
 
-    CheckResult::pass("built-in plugins", "built-in plugin registry loads successfully")
+    CheckResult::pass(
+        "built-in plugins",
+        "built-in plugin registry loads successfully",
+    )
 }
 
 fn render_human(report: &DoctorReport) {
@@ -366,7 +475,10 @@ mod tests {
 
     #[test]
     fn doctor_claude_reports_missing_settings() {
-        let home = env::temp_dir().join(format!("tkn-doctor-claude-missing-{}", uuid::Uuid::new_v4()));
+        let home = env::temp_dir().join(format!(
+            "tkn-doctor-claude-missing-{}",
+            uuid::Uuid::new_v4()
+        ));
         fs::create_dir_all(&home).unwrap();
 
         let report = doctor_claude_at(&home);
@@ -378,17 +490,23 @@ mod tests {
 
     #[test]
     fn doctor_claude_reports_invalid_json() {
-        let home = env::temp_dir().join(format!("tkn-doctor-claude-invalid-{}", uuid::Uuid::new_v4()));
+        let home = env::temp_dir().join(format!(
+            "tkn-doctor-claude-invalid-{}",
+            uuid::Uuid::new_v4()
+        ));
         let settings_path = hook::claude_settings_path(&home);
         fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
         fs::write(&settings_path, "{invalid").unwrap();
 
         let report = doctor_claude_at(&home);
         assert!(report.has_failures());
-        assert!(report
-            .checks
-            .iter()
-            .any(|check| check.name == "Claude settings JSON" && check.status == CheckStatus::Fail));
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "Claude settings JSON"
+                    && check.status == CheckStatus::Fail)
+        );
 
         let _ = fs::remove_dir_all(home);
     }
@@ -423,10 +541,13 @@ mod tests {
         .unwrap();
 
         let report = doctor_claude_at(&home);
-        assert!(report
-            .checks
-            .iter()
-            .any(|check| check.name == "Bash PreToolUse hook" && check.status == CheckStatus::Fail));
+        assert!(
+            report
+                .checks
+                .iter()
+                .any(|check| check.name == "Bash PreToolUse hook"
+                    && check.status == CheckStatus::Fail)
+        );
 
         let _ = fs::remove_dir_all(home);
     }
@@ -444,7 +565,8 @@ mod tests {
 
     #[test]
     fn doctor_codex_reports_missing_agents() {
-        let repo = env::temp_dir().join(format!("tkn-doctor-codex-missing-{}", uuid::Uuid::new_v4()));
+        let repo =
+            env::temp_dir().join(format!("tkn-doctor-codex-missing-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(repo.join(".git")).unwrap();
 
         let report = doctor_codex_for_repo(Ok(repo.clone()), true);
@@ -463,13 +585,18 @@ mod tests {
         setup_codex_repo(&repo).unwrap();
         let agents_path = repo.join("AGENTS.md");
         let existing = fs::read_to_string(&agents_path).unwrap();
-        fs::write(&agents_path, format!("# Notes\n\n- Run `cargo test`\n\n{existing}")).unwrap();
+        fs::write(
+            &agents_path,
+            format!("# Notes\n\n- Run `cargo test`\n\n{existing}"),
+        )
+        .unwrap();
 
         let report = doctor_codex_for_repo(Ok(repo.clone()), true);
         assert!(report
             .checks
             .iter()
-            .any(|check| check.name == "Contradictory instructions" && check.status == CheckStatus::Warn));
+            .any(|check| check.name == "Contradictory instructions"
+                && check.status == CheckStatus::Warn));
 
         let _ = fs::remove_dir_all(repo);
     }

--- a/src/cmd/hook.rs
+++ b/src/cmd/hook.rs
@@ -7,45 +7,20 @@ use crate::storage::StorageManager;
 use super::routing;
 
 pub const TKN_HOOK_COMMAND: &str = "tkn hook run";
+pub const TKN_CODEX_HOOK_COMMAND: &str = "tkn hook run --codex";
+pub const TKN_CODEX_MATCHER: &str = "^Bash$";
 const TKN_MATCHERS: [&str; 2] = ["Bash", "Zsh"];
 
-/// Runs as the hook itself: reads stdin JSON, rewrites the command, writes to stdout.
-pub fn run() {
+/// Runs as the hook itself: reads stdin JSON and writes a hook response to stdout.
+pub fn run(codex: bool) {
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
         return;
     }
 
-    let value: serde_json::Value = match serde_json::from_str(&input) {
-        Ok(v) => v,
-        Err(_) => return,
-    };
-
-    let command = value
-        .pointer("/tool_input/command")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-
-    if routing::should_skip(command) {
-        return;
+    if let Some(response) = hook_response(&input, codex) {
+        print!("{}", serde_json::to_string(&response).unwrap());
     }
-
-    // Pass the original command as a single shell-quoted argument so it
-    // survives arg-splitting (e.g. multi-word git commit messages keep their
-    // quoting). Single-quote the value, escaping any embedded single quotes.
-    let escaped = command.replace('\'', "'\\''");
-    let new_command = format!("tkn auto -- '{escaped}'");
-    let response = serde_json::json!({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "allow",
-            "updatedInput": {
-                "command": new_command
-            }
-        }
-    });
-
-    print!("{}", serde_json::to_string(&response).unwrap());
 }
 
 pub fn install() -> i32 {
@@ -145,11 +120,24 @@ pub fn claude_settings_path(home_dir: &Path) -> PathBuf {
     claude_dir(home_dir).join("settings.json")
 }
 
+pub fn codex_dir(repo_dir: &Path) -> PathBuf {
+    repo_dir.join(".codex")
+}
+
+pub fn codex_config_path(repo_dir: &Path) -> PathBuf {
+    codex_dir(repo_dir).join("config.toml")
+}
+
+pub fn codex_hooks_path(repo_dir: &Path) -> PathBuf {
+    codex_dir(repo_dir).join("hooks.json")
+}
+
 pub fn read_settings(path: &Path) -> Result<serde_json::Value, String> {
     if path.exists() {
         let content = fs::read_to_string(path)
             .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-        serde_json::from_str(&content).map_err(|e| format!("invalid JSON in {}: {e}", path.display()))
+        serde_json::from_str(&content)
+            .map_err(|e| format!("invalid JSON in {}: {e}", path.display()))
     } else {
         Ok(serde_json::json!({}))
     }
@@ -184,6 +172,33 @@ pub fn repair_hook_settings(settings: &mut serde_json::Value) -> Result<(), Stri
     Ok(())
 }
 
+pub fn repair_codex_hook_settings(settings: &mut serde_json::Value) -> Result<(), String> {
+    let Some(settings_obj) = settings.as_object_mut() else {
+        return Err("hooks.json is not a JSON object".to_string());
+    };
+
+    let hooks = settings_obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}));
+
+    let Some(hooks_obj) = hooks.as_object_mut() else {
+        return Err("hooks.json 'hooks' is not an object".to_string());
+    };
+
+    let pre_tool_use = hooks_obj
+        .entry("PreToolUse")
+        .or_insert_with(|| serde_json::json!([]));
+
+    let Some(arr) = pre_tool_use.as_array_mut() else {
+        return Err("hooks.json 'PreToolUse' is not an array".to_string());
+    };
+
+    arr.retain(|entry| !is_tkn_hook(entry));
+    arr.push(codex_hook_entry());
+
+    Ok(())
+}
+
 pub fn hook_entries_for_matcher<'a>(
     settings: &'a serde_json::Value,
     matcher: &str,
@@ -195,10 +210,19 @@ pub fn hook_entries_for_matcher<'a>(
         .map(|entries| {
             entries
                 .iter()
-                .filter(|entry| entry.get("matcher").and_then(|value| value.as_str()) == Some(matcher))
+                .filter(|entry| {
+                    entry.get("matcher").and_then(|value| value.as_str()) == Some(matcher)
+                })
                 .collect()
         })
         .unwrap_or_default()
+}
+
+pub fn codex_hook_entries_for_matcher<'a>(
+    settings: &'a serde_json::Value,
+    matcher: &str,
+) -> Vec<&'a serde_json::Value> {
+    hook_entries_for_matcher(settings, matcher)
 }
 
 pub fn has_expected_hook_command(entry: &serde_json::Value) -> bool {
@@ -210,6 +234,21 @@ pub fn has_expected_hook_command(entry: &serde_json::Value) -> bool {
                 hook.get("command")
                     .and_then(|command| command.as_str())
                     .map(|command| command == TKN_HOOK_COMMAND)
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+pub fn has_expected_codex_hook_command(entry: &serde_json::Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(|hooks| hooks.as_array())
+        .map(|hooks| {
+            hooks.iter().any(|hook| {
+                hook.get("command")
+                    .and_then(|command| command.as_str())
+                    .map(|command| command == TKN_CODEX_HOOK_COMMAND)
                     .unwrap_or(false)
             })
         })
@@ -256,9 +295,74 @@ fn hook_entry(matcher: &str) -> serde_json::Value {
     })
 }
 
-fn write_settings(path: &Path, value: &serde_json::Value) -> std::io::Result<()> {
+fn codex_hook_entry() -> serde_json::Value {
+    serde_json::json!({
+        "matcher": TKN_CODEX_MATCHER,
+        "hooks": [{
+            "type": "command",
+            "command": TKN_CODEX_HOOK_COMMAND,
+            "timeout": 30,
+            "statusMessage": "Checking tkn routing"
+        }]
+    })
+}
+
+pub fn write_settings(path: &Path, value: &serde_json::Value) -> std::io::Result<()> {
     let json = serde_json::to_string_pretty(value).map_err(std::io::Error::other)?;
     fs::write(path, json)
+}
+
+fn hook_response(input: &str, codex: bool) -> Option<serde_json::Value> {
+    let value: serde_json::Value = serde_json::from_str(input).ok()?;
+    let command = value
+        .pointer("/tool_input/command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if routing::should_skip(command) {
+        return None;
+    }
+
+    if codex {
+        Some(codex_pretooluse_response(command))
+    } else {
+        Some(claude_pretooluse_response(command))
+    }
+}
+
+fn claude_pretooluse_response(command: &str) -> serde_json::Value {
+    // Pass the original command as a single shell-quoted argument so it
+    // survives arg-splitting (e.g. multi-word git commit messages keep their
+    // quoting). Single-quote the value, escaping any embedded single quotes.
+    let escaped = command.replace('\'', "'\\''");
+    let new_command = format!("tkn auto -- '{escaped}'");
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": {
+                "command": new_command
+            }
+        }
+    })
+}
+
+fn codex_pretooluse_response(command: &str) -> serde_json::Value {
+    let suggested = if routing::is_long_lived(command) {
+        format!("tkn pass -- {command}")
+    } else {
+        format!("tkn auto -- {command}")
+    };
+
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": format!(
+                "Route assistant shell commands through tkn. Rerun this command as `{suggested}`."
+            )
+        }
+    })
 }
 
 #[cfg(test)]
@@ -269,7 +373,98 @@ mod tests {
 
     #[test]
     fn run_is_noop_on_invalid_input() {
-        run();
+        assert!(hook_response("{invalid", false).is_none());
+    }
+
+    #[test]
+    fn claude_response_rewrites_simple_command() {
+        let input = serde_json::json!({
+            "tool_input": {
+                "command": "git commit -m 'hello world'"
+            }
+        })
+        .to_string();
+
+        let response = hook_response(&input, false).unwrap();
+        assert_eq!(
+            response.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&serde_json::json!(
+                "tkn auto -- 'git commit -m '\\''hello world'\\'''"
+            ))
+        );
+    }
+
+    #[test]
+    fn codex_response_blocks_simple_command_with_tkn_instruction() {
+        let input = serde_json::json!({
+            "tool_input": {
+                "command": "cargo test"
+            }
+        })
+        .to_string();
+
+        let response = hook_response(&input, true).unwrap();
+        assert_eq!(
+            response.pointer("/hookSpecificOutput/permissionDecision"),
+            Some(&serde_json::json!("deny"))
+        );
+        assert!(response
+            .pointer("/hookSpecificOutput/permissionDecisionReason")
+            .and_then(|value| value.as_str())
+            .unwrap()
+            .contains("tkn auto -- cargo test"));
+    }
+
+    #[test]
+    fn codex_response_uses_pass_for_long_lived_commands() {
+        let input = serde_json::json!({
+            "tool_input": {
+                "command": "npm run dev"
+            }
+        })
+        .to_string();
+
+        let response = hook_response(&input, true).unwrap();
+        assert!(response
+            .pointer("/hookSpecificOutput/permissionDecisionReason")
+            .and_then(|value| value.as_str())
+            .unwrap()
+            .contains("tkn pass -- npm run dev"));
+    }
+
+    #[test]
+    fn codex_response_is_noop_for_already_wrapped_command() {
+        let input = serde_json::json!({
+            "tool_input": {
+                "command": "tkn auto -- cargo test"
+            }
+        })
+        .to_string();
+
+        assert!(hook_response(&input, true).is_none());
+    }
+
+    #[test]
+    fn repair_codex_hook_settings_repairs_duplicate_entries() {
+        let mut settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{"type": "command", "command": "tkn hook run --codex"}]
+                    },
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{"type": "command", "command": "tkn hook run"}]
+                    }
+                ]
+            }
+        });
+
+        repair_codex_hook_settings(&mut settings).unwrap();
+        let entries = codex_hook_entries_for_matcher(&settings, TKN_CODEX_MATCHER);
+        assert_eq!(entries.len(), 1);
+        assert!(has_expected_codex_hook_command(entries[0]));
     }
 
     #[test]

--- a/src/cmd/reasons.rs
+++ b/src/cmd/reasons.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::HashMap;
 
 use crate::storage::StorageManager;
@@ -34,7 +35,7 @@ pub fn run() {
 
     // Sort tools by count descending
     let mut sorted: Vec<_> = by_tool.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    sorted.sort_by_key(|(_, entries)| Reverse(entries.len()));
 
     println!("Full log reads: {} total", entries.len());
     println!("{}", "-".repeat(50));
@@ -49,7 +50,7 @@ pub fn run() {
             *reason_counts.entry(&entry.reason).or_insert(0) += 1;
         }
         let mut sorted_reasons: Vec<_> = reason_counts.into_iter().collect();
-        sorted_reasons.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted_reasons.sort_by_key(|(_, count)| Reverse(*count));
 
         for (reason, count) in &sorted_reasons {
             if *count > 1 {

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -62,14 +62,22 @@ fn setup_claude() -> Result<(), String> {
 
 fn setup_codex(repo: Option<&Path>) -> Result<(), String> {
     let repo_path = resolve_setup_repo_path(repo)?;
-    let agents_path = setup_codex_repo(&repo_path)?;
+    let paths = setup_codex_repo(&repo_path)?;
     println!("Codex setup: ready");
-    println!("  AGENTS: {}", agents_path.display());
+    println!("  Config: {}", paths.config_path.display());
+    println!("  Hooks: {}", paths.hooks_path.display());
+    println!("  AGENTS: {}", paths.agents_path.display());
     println!("  Next: tkn doctor codex --repo {}", repo_path.display());
     Ok(())
 }
 
-pub(crate) fn setup_codex_repo(repo_path: &Path) -> Result<PathBuf, String> {
+pub(crate) struct CodexSetupPaths {
+    pub agents_path: PathBuf,
+    pub config_path: PathBuf,
+    pub hooks_path: PathBuf,
+}
+
+pub(crate) fn setup_codex_repo(repo_path: &Path) -> Result<CodexSetupPaths, String> {
     let agents_path = repo_path.join("AGENTS.md");
     let existing = if agents_path.exists() {
         fs::read_to_string(&agents_path)
@@ -84,7 +92,97 @@ pub(crate) fn setup_codex_repo(repo_path: &Path) -> Result<PathBuf, String> {
     fs::write(&agents_path, updated)
         .map_err(|e| format!("failed to write {}: {e}", agents_path.display()))?;
 
-    Ok(agents_path)
+    let config_path = hook::codex_config_path(repo_path);
+    ensure_parent_dir(&config_path)
+        .map_err(|e| format!("failed to prepare {}: {e}", config_path.display()))?;
+    ensure_codex_hooks_feature(&config_path)?;
+
+    let hooks_path = hook::codex_hooks_path(repo_path);
+    let mut hooks = hook::read_settings(&hooks_path)?;
+    hook::repair_codex_hook_settings(&mut hooks)?;
+    hook::write_settings(&hooks_path, &hooks)
+        .map_err(|e| format!("failed to write {}: {e}", hooks_path.display()))?;
+
+    Ok(CodexSetupPaths {
+        agents_path,
+        config_path,
+        hooks_path,
+    })
+}
+
+fn ensure_codex_hooks_feature(config_path: &Path) -> Result<(), String> {
+    let existing = if config_path.exists() {
+        fs::read_to_string(config_path)
+            .map_err(|e| format!("failed to read {}: {e}", config_path.display()))?
+    } else {
+        String::new()
+    };
+
+    if !existing.trim().is_empty() {
+        toml::from_str::<toml::Value>(&existing)
+            .map_err(|e| format!("invalid TOML in {}: {e}", config_path.display()))?;
+    }
+
+    let updated = upsert_codex_hooks_feature(&existing);
+    fs::write(config_path, updated)
+        .map_err(|e| format!("failed to write {}: {e}", config_path.display()))
+}
+
+fn upsert_codex_hooks_feature(existing: &str) -> String {
+    let normalized = existing.replace("\r\n", "\n");
+    let lines: Vec<&str> = normalized.lines().collect();
+
+    let mut in_features = false;
+    let mut features_start = None;
+    let mut features_end = lines.len();
+    let mut codex_hooks_line = None;
+
+    for (idx, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            if in_features {
+                features_end = idx;
+                break;
+            }
+            if trimmed == "[features]" {
+                in_features = true;
+                features_start = Some(idx);
+            }
+            continue;
+        }
+
+        if in_features {
+            let key = trimmed.split('=').next().map(str::trim).unwrap_or("");
+            if key == "codex_hooks" {
+                codex_hooks_line = Some(idx);
+            }
+        }
+    }
+
+    if features_start.is_none() {
+        let trimmed = normalized.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            return "[features]\ncodex_hooks = true\n".to_string();
+        }
+        return format!("{trimmed}\n\n[features]\ncodex_hooks = true\n");
+    }
+
+    let mut output = Vec::with_capacity(lines.len() + 1);
+    let insert_at = features_end;
+    for (idx, line) in lines.iter().enumerate() {
+        if Some(idx) == codex_hooks_line {
+            output.push("codex_hooks = true".to_string());
+        } else {
+            output.push((*line).to_string());
+        }
+        if codex_hooks_line.is_none() && idx + 1 == insert_at {
+            output.push("codex_hooks = true".to_string());
+        }
+    }
+
+    let mut joined = output.join("\n");
+    joined.push('\n');
+    joined
 }
 
 #[cfg(test)]
@@ -101,17 +199,20 @@ mod tests {
         let repo = env::temp_dir().join(format!("tkn-setup-codex-create-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(repo.join(".git")).unwrap();
 
-        let agents_path = setup_codex_repo(&repo).unwrap();
-        let content = fs::read_to_string(agents_path).unwrap();
+        let paths = setup_codex_repo(&repo).unwrap();
+        let content = fs::read_to_string(paths.agents_path).unwrap();
         assert!(content.contains(CODEX_BEGIN_MARKER));
         assert!(codex_block_matches_current(&content));
+        assert!(paths.config_path.exists());
+        assert!(paths.hooks_path.exists());
 
         let _ = fs::remove_dir_all(repo);
     }
 
     #[test]
     fn setup_codex_repo_preserves_existing_user_content() {
-        let repo = env::temp_dir().join(format!("tkn-setup-codex-preserve-{}", uuid::Uuid::new_v4()));
+        let repo =
+            env::temp_dir().join(format!("tkn-setup-codex-preserve-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(repo.join(".git")).unwrap();
         let agents_path = repo.join("AGENTS.md");
         fs::write(&agents_path, "# Notes\n\nKeep this.\n").unwrap();
@@ -145,15 +246,40 @@ mod tests {
 
     #[test]
     fn setup_codex_repo_is_idempotent() {
-        let repo = env::temp_dir().join(format!("tkn-setup-codex-idempotent-{}", uuid::Uuid::new_v4()));
+        let repo = env::temp_dir().join(format!(
+            "tkn-setup-codex-idempotent-{}",
+            uuid::Uuid::new_v4()
+        ));
         fs::create_dir_all(repo.join(".git")).unwrap();
 
         let first = setup_codex_repo(&repo).unwrap();
-        let first_content = fs::read_to_string(&first).unwrap();
+        let first_content = fs::read_to_string(&first.agents_path).unwrap();
         setup_codex_repo(&repo).unwrap();
-        let second_content = fs::read_to_string(&first).unwrap();
+        let second_content = fs::read_to_string(&first.agents_path).unwrap();
 
         assert_eq!(first_content, second_content);
+
+        let _ = fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn setup_codex_repo_preserves_config_and_enables_hooks() {
+        let repo = env::temp_dir().join(format!("tkn-setup-codex-config-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        let config_path = hook::codex_config_path(&repo);
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(
+            &config_path,
+            "[features]\napps = true\n\n[tools]\nweb_search = true\n",
+        )
+        .unwrap();
+
+        setup_codex_repo(&repo).unwrap();
+        let content = fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains("[features]"));
+        assert!(content.contains("apps = true"));
+        assert!(content.contains("codex_hooks = true"));
+        assert!(content.contains("[tools]\nweb_search = true"));
 
         let _ = fs::remove_dir_all(repo);
     }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
 use crate::storage::StorageManager;
@@ -101,7 +102,7 @@ pub fn run(reset: Option<&str>, reset_failures: Option<&str>) -> i32 {
 
         // Sort entries within each group by count descending
         for entries in groups.values_mut() {
-            entries.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+            entries.sort_by_key(|(_, stats)| Reverse(stats.count));
         }
 
         // Sort groups by total count descending

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 pub const CODEX_BEGIN_MARKER: &str = "<!-- tkn:begin codex -->";
 pub const CODEX_END_MARKER: &str = "<!-- tkn:end codex -->";
-pub const CODEX_TEMPLATE_VERSION: u32 = 1;
+pub const CODEX_TEMPLATE_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -76,7 +76,9 @@ impl CheckResult {
 
 impl TargetReport {
     pub fn has_failures(&self) -> bool {
-        self.checks.iter().any(|check| check.status == CheckStatus::Fail)
+        self.checks
+            .iter()
+            .any(|check| check.status == CheckStatus::Fail)
     }
 }
 
@@ -170,6 +172,7 @@ pub fn codex_managed_block() -> String {
 <!-- tkn:template-version {CODEX_TEMPLATE_VERSION} -->\n\
 ## tkn Codex Workflow\n\
 \n\
+- This repo enables a Codex `PreToolUse` hook in `.codex/hooks.json` that blocks bare Bash commands and asks Codex to rerun them through `tkn`.\n\
 - Default to `tkn auto -- <command>`.\n\
 - Use `tkn exec -- <command>` for deterministic captured output.\n\
 - Use `tkn pass -- <command>` for interactive, long-lived, or streaming commands.\n\
@@ -243,7 +246,11 @@ pub fn contradictory_codex_lines(content: &str) -> Vec<String> {
 
     for raw_line in stripped.lines() {
         let line = raw_line.trim();
-        if line.is_empty() || line.contains("tkn auto --") || line.contains("tkn exec --") || line.contains("tkn pass --") {
+        if line.is_empty()
+            || line.contains("tkn auto --")
+            || line.contains("tkn exec --")
+            || line.contains("tkn pass --")
+        {
             continue;
         }
 
@@ -299,9 +306,7 @@ mod tests {
 
     #[test]
     fn updates_existing_codex_block_in_place() {
-        let original = format!(
-            "Intro\n\n{CODEX_BEGIN_MARKER}\nold\n{CODEX_END_MARKER}\n\nOutro\n"
-        );
+        let original = format!("Intro\n\n{CODEX_BEGIN_MARKER}\nold\n{CODEX_END_MARKER}\n\nOutro\n");
         let updated = upsert_codex_managed_block(&original);
         assert!(updated.contains("## tkn Codex Workflow"));
         assert!(updated.starts_with("Intro\n\n"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ enum Commands {
         #[arg(long)]
         lines: Option<String>,
     },
-    /// Install or uninstall the Claude Code hook
+    /// Install, uninstall, or run assistant hooks
     Hook {
         #[command(subcommand)]
         action: HookAction,
@@ -144,8 +144,11 @@ enum HookAction {
     Install,
     /// Uninstall the Claude Code hook
     Uninstall,
-    /// Run the Claude Code hook (reads stdin, rewrites command, writes stdout)
+    /// Run an assistant hook (reads stdin, writes stdout)
     Run {
+        /// Run in Codex PreToolUse mode
+        #[arg(long, hide = true)]
+        codex: bool,
         /// Extra arguments (ignored, passed by Claude Code)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
         _args: Vec<String>,
@@ -176,15 +179,13 @@ fn main() {
         Commands::Hook { action } => match action {
             HookAction::Install => cmd::hook::install(),
             HookAction::Uninstall => cmd::hook::uninstall(),
-            HookAction::Run { .. } => {
-                cmd::hook::run();
+            HookAction::Run { codex, .. } => {
+                cmd::hook::run(codex);
                 0
             }
         },
         Commands::Setup { target, repo } => cmd::setup::run(target, repo.as_deref()),
-        Commands::Doctor { target, repo, json } => {
-            cmd::doctor::run(target, repo.as_deref(), json)
-        }
+        Commands::Doctor { target, repo, json } => cmd::doctor::run(target, repo.as_deref(), json),
         Commands::Clean { logs, stats } => cmd::clean::run(logs, stats),
         Commands::Analyze { action } => match action {
             AnalyzeAction::Scan => cmd::analyze::scan(),

--- a/src/storage/log_store.rs
+++ b/src/storage/log_store.rs
@@ -1,3 +1,4 @@
+use std::cmp::Reverse;
 use std::fs;
 
 use crate::types::LogEntry;
@@ -50,7 +51,7 @@ impl StorageManager {
                 }
             }
         }
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.sort_by_key(|entry| Reverse(entry.timestamp));
         Ok(entries)
     }
 }

--- a/src/tool_config.rs
+++ b/src/tool_config.rs
@@ -410,11 +410,7 @@ pub fn builtin_plugins() -> Vec<(&'static str, &'static str, &'static str)> {
             "uv-pip-install",
             include_str!("../plugins/uv/install.toml"),
         ),
-        (
-            "uv",
-            "uv-sync",
-            include_str!("../plugins/uv/sync.toml"),
-        ),
+        ("uv", "uv-sync", include_str!("../plugins/uv/sync.toml")),
         ("uv", "uv-run", include_str!("../plugins/uv/run.toml")),
         // helm
         (
@@ -528,16 +524,8 @@ pub fn builtin_plugins() -> Vec<(&'static str, &'static str, &'static str)> {
             "yarn-install",
             include_str!("../plugins/yarn/install.toml"),
         ),
-        (
-            "yarn",
-            "yarn-add",
-            include_str!("../plugins/yarn/add.toml"),
-        ),
-        (
-            "yarn",
-            "yarn-run",
-            include_str!("../plugins/yarn/run.toml"),
-        ),
+        ("yarn", "yarn-add", include_str!("../plugins/yarn/add.toml")),
+        ("yarn", "yarn-run", include_str!("../plugins/yarn/run.toml")),
         // vite
         (
             "vite",
@@ -587,11 +575,7 @@ pub fn builtin_plugins() -> Vec<(&'static str, &'static str, &'static str)> {
             "flux-reconcile",
             include_str!("../plugins/flux/reconcile.toml"),
         ),
-        (
-            "flux",
-            "flux-get",
-            include_str!("../plugins/flux/get.toml"),
-        ),
+        ("flux", "flux-get", include_str!("../plugins/flux/get.toml")),
         // mise
         (
             "mise",


### PR DESCRIPTION
## Summary

Adds repo-local Codex hook setup for tkn so Codex can enforce routing shell commands through `tkn`.

## What changed

- Adds `tkn hook run --codex` for Codex `PreToolUse` events.
- Updates `tkn setup codex` to create or repair `.codex/config.toml`, `.codex/hooks.json`, and the managed `AGENTS.md` block.
- Updates `tkn doctor codex` to validate the Codex hooks feature flag and PreToolUse hook entry.
- Documents the Codex hook flow and its current block-and-rerun behavior.

## Why

Codex currently supports `PreToolUse` hooks, but command input rewrites are parsed and not supported. The hook therefore blocks bare Bash commands and asks Codex to rerun them through `tkn auto --` or `tkn pass --` for long-lived commands.

## Validation

- `cargo test`
- `cargo clippy`
- `git diff --check`
- `rustfmt --check src/main.rs src/cmd/hook.rs src/cmd/setup.rs src/cmd/doctor.rs src/integration.rs`