### PR TITLE
feat: add Codex support to hook setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ Codex support is repo-based. `tkn` manages a Codex hook configuration and a smal
 tkn setup codex --repo /path/to/repo
 ```
 
+You can also install the repo-level Codex integration or remove its managed hook entry and `AGENTS.md` block through the hook CLI:
+
+```sh
+tkn hook install codex --repo /path/to/repo
+tkn hook uninstall codex --repo /path/to/repo
+```
+
+When `--repo` is present, the hook CLI defaults to Codex if no target is given.
+
 This creates or updates:
 
 - `.codex/config.toml` with `features.codex_hooks = true`
@@ -178,8 +187,8 @@ Each plugin defines flag transforms (adding `--no-pager`, removing `--color=alwa
 | `tkn clean` | Clear stats and logs |
 | `tkn setup <claude\|codex\|all>` | Install or repair assistant integration |
 | `tkn doctor [claude\|codex\|all] [--json]` | Verify tkn, Claude, and Codex setup |
-| `tkn hook install` | Install the Claude Code hook directly |
-| `tkn hook uninstall` | Remove the Claude Code hook |
+| `tkn hook install [claude\|codex\|all] [--repo path]` | Install assistant hooks directly |
+| `tkn hook uninstall [claude\|codex\|all] [--repo path]` | Remove assistant hooks |
 | `tkn hook run --codex` | Run the Codex `PreToolUse` hook mode |
 
 ## Writing plugins

--- a/src/cmd/hook.rs
+++ b/src/cmd/hook.rs
@@ -2,7 +2,10 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use crate::cmd::setup;
+use crate::integration::{content_without_codex_block, resolve_setup_repo_path};
 use crate::storage::StorageManager;
+use crate::AssistantTarget;
 
 use super::routing;
 
@@ -23,25 +26,44 @@ pub fn run(codex: bool) {
     }
 }
 
-pub fn install() -> i32 {
-    let storage = StorageManager::new();
-    if let Err(e) = storage.init() {
-        eprintln!("tkn: failed to initialize storage: {e}");
-        return 1;
-    }
+pub fn install(target: AssistantTarget, repo: Option<&Path>) -> i32 {
+    match target {
+        AssistantTarget::Claude => install_claude(),
+        AssistantTarget::Codex => install_codex(repo),
+        AssistantTarget::All => {
+            let claude_result = install_claude_result();
+            let codex_result = install_codex_result(repo);
 
-    let home_dir = match dirs::home_dir() {
-        Some(home_dir) => home_dir,
-        None => {
-            eprintln!("tkn: cannot determine home directory");
-            return 1;
+            match (&claude_result, &codex_result) {
+                (Ok(claude_path), Ok(codex_paths)) => {
+                    print_claude_install_success(claude_path);
+                    print_codex_install_success(codex_paths);
+                    0
+                }
+                (Ok(claude_path), Err(err)) => {
+                    print_claude_install_success(claude_path);
+                    eprintln!("tkn: Claude hook installed, Codex hook failed: {err}");
+                    1
+                }
+                (Err(err), Ok(codex_paths)) => {
+                    print_codex_install_success(codex_paths);
+                    eprintln!("tkn: Codex hook installed, Claude hook failed: {err}");
+                    1
+                }
+                (Err(claude_err), Err(codex_err)) => {
+                    eprintln!("tkn: Claude hook failed: {claude_err}");
+                    eprintln!("tkn: Codex hook failed: {codex_err}");
+                    1
+                }
+            }
         }
-    };
+    }
+}
 
-    match install_for_home(&home_dir) {
+fn install_claude() -> i32 {
+    match install_claude_result() {
         Ok(settings_path) => {
-            println!("tkn hook installed successfully.");
-            println!("  Settings: {}", settings_path.display());
+            print_claude_install_success(&settings_path);
             0
         }
         Err(e) => {
@@ -49,6 +71,46 @@ pub fn install() -> i32 {
             1
         }
     }
+}
+
+fn install_claude_result() -> Result<PathBuf, String> {
+    let storage = StorageManager::new();
+    storage
+        .init()
+        .map_err(|e| format!("failed to initialize storage: {e}"))?;
+
+    let home_dir = dirs::home_dir().ok_or_else(|| "cannot determine home directory".to_string())?;
+    install_for_home(&home_dir)
+}
+
+fn install_codex(repo: Option<&Path>) -> i32 {
+    match install_codex_result(repo) {
+        Ok(paths) => {
+            print_codex_install_success(&paths);
+            0
+        }
+        Err(e) => {
+            eprintln!("tkn: {e}");
+            1
+        }
+    }
+}
+
+fn install_codex_result(repo: Option<&Path>) -> Result<setup::CodexSetupPaths, String> {
+    let repo_path = resolve_setup_repo_path(repo)?;
+    setup::setup_codex_repo(&repo_path)
+}
+
+fn print_claude_install_success(settings_path: &Path) {
+    println!("tkn Claude hook installed successfully.");
+    println!("  Settings: {}", settings_path.display());
+}
+
+fn print_codex_install_success(paths: &setup::CodexSetupPaths) {
+    println!("tkn Codex hook installed successfully.");
+    println!("  Config: {}", paths.config_path.display());
+    println!("  Hooks: {}", paths.hooks_path.display());
+    println!("  AGENTS: {}", paths.agents_path.display());
 }
 
 pub fn install_for_home(home_dir: &Path) -> Result<PathBuf, String> {
@@ -70,12 +132,58 @@ pub fn install_for_home(home_dir: &Path) -> Result<PathBuf, String> {
     Ok(settings_path)
 }
 
-pub fn uninstall() -> i32 {
+pub fn uninstall(target: AssistantTarget, repo: Option<&Path>) -> i32 {
+    match target {
+        AssistantTarget::Claude => uninstall_claude(),
+        AssistantTarget::Codex => uninstall_codex(repo),
+        AssistantTarget::All => {
+            let claude_result = uninstall_claude_result();
+            let codex_result = uninstall_codex_result(repo);
+
+            match (&claude_result, &codex_result) {
+                (Ok(_), Ok(codex_path)) => {
+                    print_claude_uninstall_success();
+                    print_codex_uninstall_success(codex_path);
+                    0
+                }
+                (Ok(_), Err(err)) => {
+                    print_claude_uninstall_success();
+                    eprintln!("tkn: Claude hook removed, Codex hook failed: {err}");
+                    1
+                }
+                (Err(err), Ok(codex_path)) => {
+                    print_codex_uninstall_success(codex_path);
+                    eprintln!("tkn: Codex hook removed, Claude hook failed: {err}");
+                    1
+                }
+                (Err(claude_err), Err(codex_err)) => {
+                    eprintln!("tkn: Claude hook failed: {claude_err}");
+                    eprintln!("tkn: Codex hook failed: {codex_err}");
+                    1
+                }
+            }
+        }
+    }
+}
+
+fn uninstall_claude() -> i32 {
+    match uninstall_claude_result() {
+        Ok(_) => {
+            print_claude_uninstall_success();
+            0
+        }
+        Err(e) => {
+            eprintln!("tkn: {e}");
+            1
+        }
+    }
+}
+
+fn uninstall_claude_result() -> Result<(), String> {
     let home_dir = match dirs::home_dir() {
         Some(home_dir) => home_dir,
         None => {
-            eprintln!("tkn: cannot determine home directory");
-            return 1;
+            return Err("cannot determine home directory".to_string());
         }
     };
 
@@ -89,8 +197,7 @@ pub fn uninstall() -> i32 {
         let mut settings = match read_settings(&settings_path) {
             Ok(settings) => settings,
             Err(e) => {
-                eprintln!("tkn: {e}");
-                return 1;
+                return Err(e);
             }
         };
 
@@ -103,13 +210,65 @@ pub fn uninstall() -> i32 {
         }
 
         if let Err(e) = write_settings(&settings_path, &settings) {
-            eprintln!("tkn: failed to update settings: {e}");
-            return 1;
+            return Err(format!("failed to update settings: {e}"));
         }
     }
 
-    println!("tkn hook uninstalled successfully.");
-    0
+    Ok(())
+}
+
+fn uninstall_codex(repo: Option<&Path>) -> i32 {
+    match uninstall_codex_result(repo) {
+        Ok(hooks_path) => {
+            print_codex_uninstall_success(&hooks_path);
+            0
+        }
+        Err(e) => {
+            eprintln!("tkn: {e}");
+            1
+        }
+    }
+}
+
+fn uninstall_codex_result(repo: Option<&Path>) -> Result<PathBuf, String> {
+    let repo_path = resolve_setup_repo_path(repo)?;
+    let hooks_path = codex_hooks_path(&repo_path);
+    if hooks_path.exists() {
+        let mut settings = read_settings(&hooks_path)?;
+
+        if let Some(hooks) = settings.get_mut("hooks") {
+            if let Some(pre_tool_use) = hooks.get_mut("PreToolUse") {
+                if let Some(arr) = pre_tool_use.as_array_mut() {
+                    arr.retain(|entry| !is_tkn_hook(entry));
+                }
+            }
+        }
+
+        write_settings(&hooks_path, &settings)
+            .map_err(|e| format!("failed to update {}: {e}", hooks_path.display()))?;
+    }
+
+    let agents_path = repo_path.join("AGENTS.md");
+    if agents_path.exists() {
+        let existing = fs::read_to_string(&agents_path)
+            .map_err(|e| format!("failed to read {}: {e}", agents_path.display()))?;
+        let updated = content_without_codex_block(&existing);
+        if updated != existing {
+            fs::write(&agents_path, updated)
+                .map_err(|e| format!("failed to update {}: {e}", agents_path.display()))?;
+        }
+    }
+
+    Ok(hooks_path)
+}
+
+fn print_claude_uninstall_success() {
+    println!("tkn Claude hook uninstalled successfully.");
+}
+
+fn print_codex_uninstall_success(hooks_path: &Path) {
+    println!("tkn Codex hook uninstalled successfully.");
+    println!("  Hooks: {}", hooks_path.display());
 }
 
 pub fn claude_dir(home_dir: &Path) -> PathBuf {
@@ -369,6 +528,8 @@ fn codex_pretooluse_response(command: &str) -> serde_json::Value {
 mod tests {
     use std::env;
 
+    use crate::integration::CODEX_BEGIN_MARKER;
+
     use super::*;
 
     #[test]
@@ -465,6 +626,22 @@ mod tests {
         let entries = codex_hook_entries_for_matcher(&settings, TKN_CODEX_MATCHER);
         assert_eq!(entries.len(), 1);
         assert!(has_expected_codex_hook_command(entries[0]));
+    }
+
+    #[test]
+    fn uninstall_codex_removes_tkn_hook_entries() {
+        let repo =
+            env::temp_dir().join(format!("tkn-hook-codex-uninstall-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        setup::setup_codex_repo(&repo).unwrap();
+
+        let hooks_path = uninstall_codex_result(Some(&repo)).unwrap();
+        let settings = read_settings(&hooks_path).unwrap();
+        assert!(codex_hook_entries_for_matcher(&settings, TKN_CODEX_MATCHER).is_empty());
+        let agents = fs::read_to_string(repo.join("AGENTS.md")).unwrap();
+        assert!(!agents.contains(CODEX_BEGIN_MARKER));
+
+        let _ = fs::remove_dir_all(repo);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,10 +140,22 @@ enum AnalyzeAction {
 
 #[derive(Subcommand)]
 enum HookAction {
-    /// Install the Claude Code hook
-    Install,
-    /// Uninstall the Claude Code hook
-    Uninstall,
+    /// Install an assistant hook
+    Install {
+        #[arg(value_enum)]
+        target: Option<AssistantTarget>,
+        /// Repository path for Codex repo-level hook setup
+        #[arg(long)]
+        repo: Option<PathBuf>,
+    },
+    /// Uninstall an assistant hook
+    Uninstall {
+        #[arg(value_enum)]
+        target: Option<AssistantTarget>,
+        /// Repository path for Codex repo-level hook removal
+        #[arg(long)]
+        repo: Option<PathBuf>,
+    },
     /// Run an assistant hook (reads stdin, writes stdout)
     Run {
         /// Run in Codex PreToolUse mode
@@ -177,8 +189,14 @@ fn main() {
             cmd::logs::run(id.as_deref(), reason.as_deref(), lines.as_deref())
         }
         Commands::Hook { action } => match action {
-            HookAction::Install => cmd::hook::install(),
-            HookAction::Uninstall => cmd::hook::uninstall(),
+            HookAction::Install { target, repo } => {
+                let target = hook_target_or_default(target, repo.as_ref());
+                cmd::hook::install(target, repo.as_deref())
+            }
+            HookAction::Uninstall { target, repo } => {
+                let target = hook_target_or_default(target, repo.as_ref());
+                cmd::hook::uninstall(target, repo.as_deref())
+            }
             HookAction::Run { codex, .. } => {
                 cmd::hook::run(codex);
                 0
@@ -207,4 +225,15 @@ fn main() {
     };
 
     std::process::exit(exit_code);
+}
+
+fn hook_target_or_default(
+    target: Option<AssistantTarget>,
+    repo: Option<&PathBuf>,
+) -> AssistantTarget {
+    target.unwrap_or(if repo.is_some() {
+        AssistantTarget::Codex
+    } else {
+        AssistantTarget::Claude
+    })
 }


### PR DESCRIPTION
## Summary
- Extend `tkn hook install` and `tkn hook uninstall` to accept `claude`, `codex`, or `all`, with `--repo` support for Codex repo-level setup
- Route Codex hook install/uninstall through the existing repo bootstrap path and remove the managed `AGENTS.md` block on uninstall
- Update the README to document the new hook CLI usage and default behavior when `--repo` is present

## Testing
- Added regression coverage for Codex hook uninstall cleanup
- Ran `cargo fmt --check`, `cargo test`, and `cargo clippy -- -D warnings` successfully
- Verified `tkn hook install --help` reflects the new target and repo options