### PR TITLE
fix: draft releases until assets upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
-          release-type: rust
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
   build:
     needs: release-please
@@ -84,3 +85,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh release upload "$TAG" artifacts/tkn-*.tar.gz --repo "${{ github.repository }}"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release edit "$TAG" --draft=false --latest --repo "${{ github.repository }}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "rust",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "draft": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary

- create release-please releases as drafts so the latest release endpoint does not expose an assetless release
- publish the release only after packaged binaries are uploaded
- wire release-please to the manifest config where the draft option is defined

## Root cause

release-please published the GitHub release before the build matrix finished uploading binaries. During that window, the install script resolved the new latest release and attempted to download an asset that did not exist yet, causing a 404.

## Validation

- jq . release-please-config.json >/dev/null
- ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/release.yml\")"
- git diff --check
