### PR TITLE
fix: prevent duplicate release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,24 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.create-release.outputs.release_created }}
+      tag_name: ${{ steps.create-release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
-        id: release
+      - name: Create GitHub release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        id: create-release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
+
+      - name: Create or update release PR
+        if: steps.create-release.outputs.release_created != 'true'
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          skip-github-release: true
 
   build:
     needs: release-please
@@ -52,7 +62,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- split the Release Please workflow into release creation and release-PR maintenance modes
- keep draft releases for asset upload/publish, but skip next release-PR creation when a release was just created
- quote `GITHUB_ENV` in the cross-compilation setup script so the workflow passes actionlint

## Context
PR #42 was generated because Release Please created v0.6.3 as a draft release, then immediately tried to build the next release PR before that draft release was visible as the latest release boundary. That caused old conventional commits to be collected again.

## Validation
- `actionlint .github/workflows/release.yml`