### PR TITLE
feat: make Codex hook install global by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Start with a health check:
 tkn doctor
 ```
 
-This verifies local `~/.tkn` storage, built-in plugin availability, Claude hook state, and Codex repo hook state.
+This verifies local `~/.tkn` storage, built-in plugin availability, Claude hook state, and Codex hook state.
 
 ### Claude Code (machine-level hook)
 
@@ -94,28 +94,28 @@ To remove the hook:
 tkn hook uninstall
 ```
 
-### Codex (repo-level hook)
+### Codex (global hook)
 
-Codex support is repo-based. `tkn` manages a Codex hook configuration and a small instructions block inside the target repo:
-
-```sh
-tkn setup codex --repo /path/to/repo
-```
-
-You can also install the repo-level Codex integration or remove its managed hook entry and `AGENTS.md` block through the hook CLI:
+By default, `tkn` manages a global Codex hook configuration and a small instructions block in `~/.codex`:
 
 ```sh
-tkn hook install codex --repo /path/to/repo
-tkn hook uninstall codex --repo /path/to/repo
+tkn setup codex
 ```
 
-When no target is given, the hook CLI installs both Claude and Codex hooks. For Codex, it uses the current git repository unless `--repo` is provided.
+You can also install or remove the global Codex integration through the hook CLI:
+
+```sh
+tkn hook install codex
+tkn hook uninstall codex
+```
+
+When no target is given, the hook CLI installs both Claude and Codex hooks. For Codex, it uses global `~/.codex` unless `--repo` is provided.
 
 This creates or updates:
 
-- `.codex/config.toml` with `features.codex_hooks = true`
-- `.codex/hooks.json` with a Bash `PreToolUse` hook that runs `tkn hook run --codex`
-- `AGENTS.md` with a managed section that tells Codex to default to:
+- `~/.codex/config.toml` with `features.codex_hooks = true`
+- `~/.codex/hooks.json` with a Bash `PreToolUse` hook that runs `tkn hook run --codex`
+- `~/.codex/AGENTS.md` with a managed section that tells Codex to default to:
 
 - `tkn auto -- <command>`
 - `tkn exec -- <command>` for deterministic captured output
@@ -123,9 +123,18 @@ This creates or updates:
 
 Codex does not currently support rewriting `PreToolUse` command input, so the hook blocks bare Bash commands and asks Codex to rerun them through `tkn`.
 
-To verify that a repo still has the current managed block:
+For a repo-local Codex setup instead of the global one, pass `--repo`:
 
 ```sh
+tkn setup codex --repo /path/to/repo
+tkn hook install codex --repo /path/to/repo
+tkn hook uninstall codex --repo /path/to/repo
+```
+
+To verify Codex setup:
+
+```sh
+tkn doctor codex
 tkn doctor codex --repo /path/to/repo
 ```
 
@@ -215,7 +224,7 @@ Place custom plugins in `~/.tkn/tools/` to override or extend built-ins.
 
 - Run `tkn doctor` after install or upgrade to catch missing hooks, stale `AGENTS.md` blocks, or local permission problems.
 - If Claude is misconfigured, rerun `tkn setup claude`.
-- If Codex stops using `tkn` in a repo, rerun `tkn setup codex --repo /path/to/repo`.
+- If Codex stops using `tkn`, rerun `tkn setup codex` for global setup or `tkn setup codex --repo /path/to/repo` for repo-local setup.
 
 ## License
 

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -135,12 +135,50 @@ fn doctor_claude_at(home_dir: &Path) -> TargetReport {
 }
 
 fn doctor_codex(repo: Option<&Path>) -> TargetReport {
-    let repo_result = integration::resolve_doctor_repo_path(repo);
-    doctor_codex_for_repo(repo_result, integration::command_on_path("codex"))
+    let target_result = resolve_codex_doctor_target(repo);
+    doctor_codex_for_target(target_result, integration::command_on_path("codex"))
 }
 
-fn doctor_codex_for_repo(
-    repo_result: Result<std::path::PathBuf, String>,
+#[derive(Clone, Debug)]
+struct CodexDoctorTarget {
+    discovery_name: &'static str,
+    discovery_message: String,
+    config_path: std::path::PathBuf,
+    hooks_path: std::path::PathBuf,
+    agents_path: std::path::PathBuf,
+    setup_command: String,
+}
+
+fn resolve_codex_doctor_target(repo: Option<&Path>) -> Result<CodexDoctorTarget, String> {
+    match repo {
+        Some(repo) => {
+            let repo_path = integration::resolve_doctor_repo_path(Some(repo))?;
+            Ok(CodexDoctorTarget {
+                discovery_name: "repository discovery",
+                discovery_message: format!("using {}", repo_path.display()),
+                config_path: hook::codex_config_path(&repo_path),
+                hooks_path: hook::codex_hooks_path(&repo_path),
+                agents_path: repo_path.join("AGENTS.md"),
+                setup_command: format!("tkn setup codex --repo {}", repo_path.display()),
+            })
+        }
+        None => {
+            let home_dir =
+                dirs::home_dir().ok_or_else(|| "cannot determine home directory".to_string())?;
+            Ok(CodexDoctorTarget {
+                discovery_name: "global Codex home",
+                discovery_message: format!("using {}", hook::codex_home_dir(&home_dir).display()),
+                config_path: hook::codex_global_config_path(&home_dir),
+                hooks_path: hook::codex_global_hooks_path(&home_dir),
+                agents_path: hook::codex_home_dir(&home_dir).join("AGENTS.md"),
+                setup_command: "tkn setup codex".to_string(),
+            })
+        }
+    }
+}
+
+fn doctor_codex_for_target(
+    target_result: Result<CodexDoctorTarget, String>,
     codex_on_path: bool,
 ) -> TargetReport {
     let mut checks = Vec::new();
@@ -155,19 +193,19 @@ fn doctor_codex_for_repo(
         ));
     }
 
-    let repo_path = match repo_result {
-        Ok(repo_path) => {
+    let target = match target_result {
+        Ok(target) => {
             checks.push(CheckResult::pass(
-                "repository discovery",
-                format!("using {}", repo_path.display()),
+                target.discovery_name,
+                target.discovery_message.clone(),
             ));
-            repo_path
+            target
         }
         Err(e) => {
             checks.push(CheckResult::fail(
-                "repository discovery",
+                "Codex target discovery",
                 e,
-                "Run `tkn doctor codex --repo <path>` from a git repository.",
+                "Run `tkn doctor codex` for global setup or pass `--repo <path>` for repo setup.",
             ));
             return TargetReport {
                 target: "codex".to_string(),
@@ -176,17 +214,20 @@ fn doctor_codex_for_repo(
         }
     };
 
-    checks.push(check_codex_config(&repo_path));
-    checks.push(check_codex_hook(&repo_path));
+    checks.push(check_codex_config(
+        &target.config_path,
+        &target.setup_command,
+    ));
+    checks.push(check_codex_hook(&target.hooks_path, &target.setup_command));
 
-    let agents_path = repo_path.join("AGENTS.md");
+    let agents_path = &target.agents_path;
     if !agents_path.exists() {
         checks.push(CheckResult::fail(
             "AGENTS.md",
             format!("{} does not exist", agents_path.display()),
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            format!("Run `{}`.", target.setup_command),
         ));
-    } else if let Ok(agents_content) = fs::read_to_string(&agents_path) {
+    } else if let Ok(agents_content) = fs::read_to_string(agents_path) {
         if integration::codex_block_matches_current(&agents_content) {
             checks.push(CheckResult::pass(
                 "Codex managed block",
@@ -196,7 +237,7 @@ fn doctor_codex_for_repo(
             checks.push(CheckResult::fail(
                 "Codex managed block",
                 "managed tkn block is missing or stale",
-                format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+                format!("Run `{}`.", target.setup_command),
             ));
         }
 
@@ -217,7 +258,7 @@ fn doctor_codex_for_repo(
             ));
         }
     } else {
-        let err = fs::read_to_string(&agents_path).unwrap_err();
+        let err = fs::read_to_string(agents_path).unwrap_err();
         checks.push(CheckResult::fail(
             "AGENTS.md",
             format!("failed to read {}: {err}", agents_path.display()),
@@ -231,17 +272,16 @@ fn doctor_codex_for_repo(
     }
 }
 
-fn check_codex_config(repo_path: &Path) -> CheckResult {
-    let config_path = hook::codex_config_path(repo_path);
+fn check_codex_config(config_path: &Path, setup_command: &str) -> CheckResult {
     if !config_path.exists() {
         return CheckResult::fail(
             "Codex hooks feature",
             format!("{} does not exist", config_path.display()),
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            format!("Run `{setup_command}`."),
         );
     }
 
-    let content = match fs::read_to_string(&config_path) {
+    let content = match fs::read_to_string(config_path) {
         Ok(content) => content,
         Err(e) => {
             return CheckResult::fail(
@@ -258,7 +298,7 @@ fn check_codex_config(repo_path: &Path) -> CheckResult {
             return CheckResult::fail(
                 "Codex hooks feature",
                 format!("invalid TOML in {}: {e}", config_path.display()),
-                format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+                format!("Run `{setup_command}`."),
             );
         }
     };
@@ -274,28 +314,27 @@ fn check_codex_config(repo_path: &Path) -> CheckResult {
         CheckResult::fail(
             "Codex hooks feature",
             "features.codex_hooks is not enabled",
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            format!("Run `{setup_command}`."),
         )
     }
 }
 
-fn check_codex_hook(repo_path: &Path) -> CheckResult {
-    let hooks_path = hook::codex_hooks_path(repo_path);
+fn check_codex_hook(hooks_path: &Path, setup_command: &str) -> CheckResult {
     if !hooks_path.exists() {
         return CheckResult::fail(
             "Codex PreToolUse hook",
             format!("{} does not exist", hooks_path.display()),
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            format!("Run `{setup_command}`."),
         );
     }
 
-    let settings = match hook::read_settings(&hooks_path) {
+    let settings = match hook::read_settings(hooks_path) {
         Ok(settings) => settings,
         Err(e) => {
             return CheckResult::fail(
                 "Codex PreToolUse hook",
                 e,
-                format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+                format!("Run `{setup_command}`."),
             );
         }
     };
@@ -310,7 +349,7 @@ fn check_codex_hook(repo_path: &Path) -> CheckResult {
         return CheckResult::fail(
             "Codex PreToolUse hook",
             "missing tkn hook entry",
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            format!("Run `{setup_command}`."),
         );
     }
 
@@ -318,7 +357,7 @@ fn check_codex_hook(repo_path: &Path) -> CheckResult {
         return CheckResult::fail(
             "Codex PreToolUse hook",
             "duplicate tkn hook entries detected",
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            format!("Run `{setup_command}`."),
         );
     }
 
@@ -326,7 +365,7 @@ fn check_codex_hook(repo_path: &Path) -> CheckResult {
         return CheckResult::fail(
             "Codex PreToolUse hook",
             "tkn hook entry does not point to `tkn hook run --codex`",
-            format!("Run `tkn setup codex --repo {}`.", repo_path.display()),
+            format!("Run `{setup_command}`."),
         );
     }
 
@@ -458,6 +497,17 @@ mod tests {
 
     use super::*;
 
+    fn codex_repo_target(repo: &Path) -> CodexDoctorTarget {
+        CodexDoctorTarget {
+            discovery_name: "repository discovery",
+            discovery_message: format!("using {}", repo.display()),
+            config_path: hook::codex_config_path(repo),
+            hooks_path: hook::codex_hooks_path(repo),
+            agents_path: repo.join("AGENTS.md"),
+            setup_command: format!("tkn setup codex --repo {}", repo.display()),
+        }
+    }
+
     #[test]
     fn doctor_json_output_shape_is_stable() {
         let report = DoctorReport {
@@ -569,7 +619,7 @@ mod tests {
             env::temp_dir().join(format!("tkn-doctor-codex-missing-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(repo.join(".git")).unwrap();
 
-        let report = doctor_codex_for_repo(Ok(repo.clone()), true);
+        let report = doctor_codex_for_target(Ok(codex_repo_target(&repo)), true);
         assert!(report
             .checks
             .iter()
@@ -591,7 +641,7 @@ mod tests {
         )
         .unwrap();
 
-        let report = doctor_codex_for_repo(Ok(repo.clone()), true);
+        let report = doctor_codex_for_target(Ok(codex_repo_target(&repo)), true);
         assert!(report
             .checks
             .iter()
@@ -607,7 +657,7 @@ mod tests {
         fs::create_dir_all(repo.join(".git")).unwrap();
         setup_codex_repo(&repo).unwrap();
 
-        let report = doctor_codex_for_repo(Ok(repo.clone()), true);
+        let report = doctor_codex_for_target(Ok(codex_repo_target(&repo)), true);
         assert!(report
             .checks
             .iter()

--- a/src/cmd/hook.rs
+++ b/src/cmd/hook.rs
@@ -97,8 +97,7 @@ fn install_codex(repo: Option<&Path>) -> i32 {
 }
 
 fn install_codex_result(repo: Option<&Path>) -> Result<setup::CodexSetupPaths, String> {
-    let repo_path = resolve_setup_repo_path(repo)?;
-    setup::setup_codex_repo(&repo_path)
+    setup::setup_codex_target(repo)
 }
 
 fn print_claude_install_success(settings_path: &Path) {
@@ -108,6 +107,7 @@ fn print_claude_install_success(settings_path: &Path) {
 
 fn print_codex_install_success(paths: &setup::CodexSetupPaths) {
     println!("tkn Codex hook installed successfully.");
+    println!("  Scope: {}", paths.scope);
     println!("  Config: {}", paths.config_path.display());
     println!("  Hooks: {}", paths.hooks_path.display());
     println!("  AGENTS: {}", paths.agents_path.display());
@@ -231,8 +231,21 @@ fn uninstall_codex(repo: Option<&Path>) -> i32 {
 }
 
 fn uninstall_codex_result(repo: Option<&Path>) -> Result<PathBuf, String> {
-    let repo_path = resolve_setup_repo_path(repo)?;
-    let hooks_path = codex_hooks_path(&repo_path);
+    let (hooks_path, agents_path) = match repo {
+        Some(repo) => {
+            let repo_path = resolve_setup_repo_path(Some(repo))?;
+            (codex_hooks_path(&repo_path), repo_path.join("AGENTS.md"))
+        }
+        None => {
+            let home_dir =
+                dirs::home_dir().ok_or_else(|| "cannot determine home directory".to_string())?;
+            (
+                codex_global_hooks_path(&home_dir),
+                codex_home_dir(&home_dir).join("AGENTS.md"),
+            )
+        }
+    };
+
     if hooks_path.exists() {
         let mut settings = read_settings(&hooks_path)?;
 
@@ -248,7 +261,6 @@ fn uninstall_codex_result(repo: Option<&Path>) -> Result<PathBuf, String> {
             .map_err(|e| format!("failed to update {}: {e}", hooks_path.display()))?;
     }
 
-    let agents_path = repo_path.join("AGENTS.md");
     if agents_path.exists() {
         let existing = fs::read_to_string(&agents_path)
             .map_err(|e| format!("failed to read {}: {e}", agents_path.display()))?;
@@ -277,6 +289,18 @@ pub fn claude_dir(home_dir: &Path) -> PathBuf {
 
 pub fn claude_settings_path(home_dir: &Path) -> PathBuf {
     claude_dir(home_dir).join("settings.json")
+}
+
+pub fn codex_home_dir(home_dir: &Path) -> PathBuf {
+    home_dir.join(".codex")
+}
+
+pub fn codex_global_config_path(home_dir: &Path) -> PathBuf {
+    codex_home_dir(home_dir).join("config.toml")
+}
+
+pub fn codex_global_hooks_path(home_dir: &Path) -> PathBuf {
+    codex_home_dir(home_dir).join("hooks.json")
 }
 
 pub fn codex_dir(repo_dir: &Path) -> PathBuf {

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -61,24 +61,66 @@ fn setup_claude() -> Result<(), String> {
 }
 
 fn setup_codex(repo: Option<&Path>) -> Result<(), String> {
-    let repo_path = resolve_setup_repo_path(repo)?;
-    let paths = setup_codex_repo(&repo_path)?;
+    let paths = setup_codex_target(repo)?;
     println!("Codex setup: ready");
+    println!("  Scope: {}", paths.scope);
     println!("  Config: {}", paths.config_path.display());
     println!("  Hooks: {}", paths.hooks_path.display());
     println!("  AGENTS: {}", paths.agents_path.display());
-    println!("  Next: tkn doctor codex --repo {}", repo_path.display());
+    println!("  Next: {}", paths.doctor_command);
     Ok(())
 }
 
 pub(crate) struct CodexSetupPaths {
+    pub scope: String,
     pub agents_path: PathBuf,
     pub config_path: PathBuf,
     pub hooks_path: PathBuf,
+    pub doctor_command: String,
+}
+
+pub(crate) fn setup_codex_target(repo: Option<&Path>) -> Result<CodexSetupPaths, String> {
+    match repo {
+        Some(repo) => {
+            let repo_path = resolve_setup_repo_path(Some(repo))?;
+            setup_codex_repo(&repo_path)
+        }
+        None => {
+            let home_dir =
+                dirs::home_dir().ok_or_else(|| "cannot determine home directory".to_string())?;
+            setup_codex_home(&home_dir)
+        }
+    }
+}
+
+pub(crate) fn setup_codex_home(home_dir: &Path) -> Result<CodexSetupPaths, String> {
+    let codex_dir = hook::codex_home_dir(home_dir);
+    setup_codex_paths(
+        "global".to_string(),
+        codex_dir.join("AGENTS.md"),
+        hook::codex_global_config_path(home_dir),
+        hook::codex_global_hooks_path(home_dir),
+        "tkn doctor codex".to_string(),
+    )
 }
 
 pub(crate) fn setup_codex_repo(repo_path: &Path) -> Result<CodexSetupPaths, String> {
-    let agents_path = repo_path.join("AGENTS.md");
+    setup_codex_paths(
+        format!("repo ({})", repo_path.display()),
+        repo_path.join("AGENTS.md"),
+        hook::codex_config_path(repo_path),
+        hook::codex_hooks_path(repo_path),
+        format!("tkn doctor codex --repo {}", repo_path.display()),
+    )
+}
+
+fn setup_codex_paths(
+    scope: String,
+    agents_path: PathBuf,
+    config_path: PathBuf,
+    hooks_path: PathBuf,
+    doctor_command: String,
+) -> Result<CodexSetupPaths, String> {
     let existing = if agents_path.exists() {
         fs::read_to_string(&agents_path)
             .map_err(|e| format!("failed to read {}: {e}", agents_path.display()))?
@@ -92,21 +134,23 @@ pub(crate) fn setup_codex_repo(repo_path: &Path) -> Result<CodexSetupPaths, Stri
     fs::write(&agents_path, updated)
         .map_err(|e| format!("failed to write {}: {e}", agents_path.display()))?;
 
-    let config_path = hook::codex_config_path(repo_path);
     ensure_parent_dir(&config_path)
         .map_err(|e| format!("failed to prepare {}: {e}", config_path.display()))?;
     ensure_codex_hooks_feature(&config_path)?;
 
-    let hooks_path = hook::codex_hooks_path(repo_path);
+    ensure_parent_dir(&hooks_path)
+        .map_err(|e| format!("failed to prepare {}: {e}", hooks_path.display()))?;
     let mut hooks = hook::read_settings(&hooks_path)?;
     hook::repair_codex_hook_settings(&mut hooks)?;
     hook::write_settings(&hooks_path, &hooks)
         .map_err(|e| format!("failed to write {}: {e}", hooks_path.display()))?;
 
     Ok(CodexSetupPaths {
+        scope,
         agents_path,
         config_path,
         hooks_path,
+        doctor_command,
     })
 }
 
@@ -207,6 +251,31 @@ mod tests {
         assert!(paths.hooks_path.exists());
 
         let _ = fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn setup_codex_home_creates_global_config() {
+        let home = env::temp_dir().join(format!("tkn-setup-codex-home-{}", uuid::Uuid::new_v4()));
+
+        let paths = setup_codex_home(&home).unwrap();
+        let content = fs::read_to_string(&paths.agents_path).unwrap();
+        let hooks = hook::read_settings(&paths.hooks_path).unwrap();
+
+        assert_eq!(paths.scope, "global");
+        assert_eq!(paths.config_path, home.join(".codex").join("config.toml"));
+        assert_eq!(paths.hooks_path, home.join(".codex").join("hooks.json"));
+        assert_eq!(paths.agents_path, home.join(".codex").join("AGENTS.md"));
+        assert!(content.contains(CODEX_BEGIN_MARKER));
+        assert!(codex_block_matches_current(&content));
+        assert!(fs::read_to_string(&paths.config_path)
+            .unwrap()
+            .contains("codex_hooks = true"));
+        assert_eq!(
+            hook::codex_hook_entries_for_matcher(&hooks, hook::TKN_CODEX_MATCHER).len(),
+            1
+        );
+
+        let _ = fs::remove_dir_all(home);
     }
 
     #[test]

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -172,7 +172,7 @@ pub fn codex_managed_block() -> String {
 <!-- tkn:template-version {CODEX_TEMPLATE_VERSION} -->\n\
 ## tkn Codex Workflow\n\
 \n\
-- This repo enables a Codex `PreToolUse` hook in `.codex/hooks.json` that blocks bare Bash commands and asks Codex to rerun them through `tkn`.\n\
+- This Codex environment enables a `PreToolUse` hook that blocks bare Bash commands and asks Codex to rerun them through `tkn`.\n\
 - Default to `tkn auto -- <command>`.\n\
 - Use `tkn exec -- <command>` for deterministic captured output.\n\
 - Use `tkn pass -- <command>` for interactive, long-lived, or streaming commands.\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ enum Commands {
         /// Assistant integration to set up
         #[arg(value_enum)]
         target: AssistantTarget,
-        /// Git repository for Codex config, hooks, and AGENTS.md
+        /// Git repository for repo-local Codex setup; omit for global ~/.codex setup
         #[arg(long)]
         repo: Option<PathBuf>,
     },
@@ -81,7 +81,7 @@ enum Commands {
         /// Assistant integration to verify
         #[arg(value_enum)]
         target: Option<AssistantTarget>,
-        /// Git repository for Codex config, hooks, and AGENTS.md
+        /// Git repository for repo-local Codex checks; omit for global ~/.codex checks
         #[arg(long)]
         repo: Option<PathBuf>,
         /// Emit machine-readable JSON output
@@ -150,7 +150,7 @@ enum HookAction {
         /// Assistant target (default: all)
         #[arg(value_enum)]
         target: Option<AssistantTarget>,
-        /// Git repository for Codex config, hooks, and AGENTS.md
+        /// Git repository for repo-local Codex setup; omit for global ~/.codex setup
         #[arg(long)]
         repo: Option<PathBuf>,
     },
@@ -159,7 +159,7 @@ enum HookAction {
         /// Assistant target (default: all)
         #[arg(value_enum)]
         target: Option<AssistantTarget>,
-        /// Git repository for Codex config, hooks, and AGENTS.md
+        /// Git repository for repo-local Codex removal; omit for global ~/.codex removal
         #[arg(long)]
         repo: Option<PathBuf>,
     },
@@ -287,7 +287,8 @@ mod tests {
             .clone();
         let hook_install_help = hook_install.render_long_help().to_string();
         assert!(hook_install_help.contains("Assistant target (default: all)"));
-        assert!(hook_install_help.contains("Git repository for Codex config, hooks, and AGENTS.md"));
+        assert!(hook_install_help
+            .contains("Git repository for repo-local Codex setup; omit for global ~/.codex setup"));
         assert!(!hook_install_help.contains("repo-level"));
     }
 }


### PR DESCRIPTION
## Summary
- Switch Codex setup, hook install/uninstall, and doctor to use global `~/.codex` by default.
- Keep `--repo` for explicit repo-local Codex setup and verification.
- Update CLI help and README copy to match the new global default.
- Add coverage for global Codex setup and doctor behavior.

## Testing
- `cargo test`
- `cargo clippy`
- Manual validation with `tkn hook install codex` and `tkn doctor codex` against a global `~/.codex` setup