### PR TITLE
feat: integrate native Codex hook rewrites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Loading priority:
 
 `tkn hook install` registers in `~/.claude/settings.json` as PreToolUse and PostToolUse hooks. `tkn hook run` reads hook JSON from stdin, rewrites Claude PreToolUse commands to `tkn auto -- <original command>`, and optimizes oversized bare Bash output in PostToolUse.
 
-Codex uses repo-local `.codex/config.toml` and `.codex/hooks.json`. `tkn hook run --codex` reads Codex hook JSON from stdin. Codex does not currently support `updatedInput` rewrites for PreToolUse, so tkn uses repo instructions for routing and a PostToolUse hook to optimize oversized bare Bash output after a command runs.
+Codex uses repo-local `.codex/config.toml` and `.codex/hooks.json`. `tkn hook run --codex` reads Codex hook JSON from stdin. Codex PreToolUse hooks rewrite Bash commands to `tkn auto -- <original command>`, while the PostToolUse hook optimizes oversized bare Bash output that bypasses routing.
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -113,15 +113,15 @@ When no target is given, the hook CLI installs both Claude and Codex hooks. For 
 
 This creates or updates:
 
-- `~/.codex/config.toml` with `features.codex_hooks = true`
-- `~/.codex/hooks.json` with a Bash `PostToolUse` hook that runs `tkn hook run --codex`
+- `~/.codex/config.toml` with `features.hooks = true`
+- `~/.codex/hooks.json` with Bash `PreToolUse` and `PostToolUse` hooks that run `tkn hook run --codex`
 - `~/.codex/AGENTS.md` with a managed section that tells Codex to default to:
 
 - `tkn auto -- <command>`
 - `tkn exec -- <command>` for deterministic captured output
 - `tkn pass -- <command>` for interactive, long-lived, or streaming commands
 
-Codex does not currently support rewriting `PreToolUse` command input. The managed instructions are the source of truth for routing commands through `tkn`; the `PostToolUse` hook catches missed bare Bash commands after they run and replaces oversized output with tkn-optimized output.
+The `PreToolUse` hook rewrites Bash commands through `tkn auto` before they run. The managed instructions keep Codex aligned with that routing, and the `PostToolUse` hook catches missed bare Bash commands after they run and replaces oversized output with tkn-optimized output.
 
 For a repo-local Codex setup instead of the global one, pass `--repo`:
 

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -222,6 +222,11 @@ fn doctor_codex_for_target(
     checks.push(check_codex_hook(
         &target.hooks_path,
         &target.setup_command,
+        "PreToolUse",
+    ));
+    checks.push(check_codex_hook(
+        &target.hooks_path,
+        &target.setup_command,
         "PostToolUse",
     ));
 
@@ -310,15 +315,15 @@ fn check_codex_config(config_path: &Path, setup_command: &str) -> CheckResult {
 
     if value
         .get("features")
-        .and_then(|features| features.get("codex_hooks"))
+        .and_then(|features| features.get("hooks"))
         .and_then(|enabled| enabled.as_bool())
         == Some(true)
     {
-        CheckResult::pass("Codex hooks feature", "features.codex_hooks is enabled")
+        CheckResult::pass("Codex hooks feature", "features.hooks is enabled")
     } else {
         CheckResult::fail(
             "Codex hooks feature",
-            "features.codex_hooks is not enabled",
+            "features.hooks is not enabled",
             format!("Run `{setup_command}`."),
         )
     }

--- a/src/cmd/hook.rs
+++ b/src/cmd/hook.rs
@@ -370,6 +370,12 @@ pub fn repair_codex_hook_settings(settings: &mut serde_json::Value) -> Result<()
 
     repair_event_hooks(
         hooks_obj,
+        PRE_TOOL_USE,
+        &[TKN_CODEX_MATCHER],
+        TKN_CODEX_HOOK_COMMAND,
+    )?;
+    repair_event_hooks(
+        hooks_obj,
         POST_TOOL_USE,
         &[TKN_CODEX_MATCHER],
         TKN_CODEX_HOOK_COMMAND,
@@ -507,17 +513,17 @@ fn hook_response(input: &str, codex: bool) -> Option<serde_json::Value> {
 
     match event {
         PRE_TOOL_USE => {
-            if codex || routing::should_skip(command) {
+            if routing::should_skip(command) {
                 return None;
             }
-            Some(claude_pretooluse_response(command))
+            Some(pretooluse_rewrite_response(command))
         }
         POST_TOOL_USE => post_tool_use_response(&value, command, codex),
         _ => None,
     }
 }
 
-fn claude_pretooluse_response(command: &str) -> serde_json::Value {
+fn pretooluse_rewrite_response(command: &str) -> serde_json::Value {
     // Pass the original command as a single shell-quoted argument so it
     // survives arg-splitting (e.g. multi-word git commit messages keep their
     // quoting). Single-quote the value, escaping any embedded single quotes.
@@ -778,7 +784,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_pretooluse_response_is_noop() {
+    fn codex_pretooluse_response_rewrites_simple_command() {
         let input = serde_json::json!({
             "tool_input": {
                 "command": "cargo test"
@@ -786,7 +792,11 @@ mod tests {
         })
         .to_string();
 
-        assert!(hook_response(&input, true).is_none());
+        let response = hook_response(&input, true).unwrap();
+        assert_eq!(
+            response.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&serde_json::json!("tkn auto -- 'cargo test'"))
+        );
     }
 
     #[test]
@@ -899,9 +909,11 @@ mod tests {
         });
 
         repair_codex_hook_settings(&mut settings).unwrap();
-        let entries = hook_entries_for_event_matcher(&settings, POST_TOOL_USE, TKN_CODEX_MATCHER);
-        assert_eq!(entries.len(), 1);
-        assert!(has_expected_codex_hook_command(entries[0]));
+        for event in [PRE_TOOL_USE, POST_TOOL_USE] {
+            let entries = hook_entries_for_event_matcher(&settings, event, TKN_CODEX_MATCHER);
+            assert_eq!(entries.len(), 1);
+            assert!(has_expected_codex_hook_command(entries[0]));
+        }
     }
 
     #[test]
@@ -913,6 +925,9 @@ mod tests {
 
         let hooks_path = uninstall_codex_result(Some(&repo)).unwrap();
         let settings = read_settings(&hooks_path).unwrap();
+        assert!(
+            hook_entries_for_event_matcher(&settings, PRE_TOOL_USE, TKN_CODEX_MATCHER).is_empty()
+        );
         assert!(
             hook_entries_for_event_matcher(&settings, POST_TOOL_USE, TKN_CODEX_MATCHER).is_empty()
         );

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -179,6 +179,7 @@ fn upsert_codex_hooks_feature(existing: &str) -> String {
     let mut in_features = false;
     let mut features_start = None;
     let mut features_end = lines.len();
+    let mut hooks_line = None;
     let mut codex_hooks_line = None;
 
     for (idx, line) in lines.iter().enumerate() {
@@ -197,7 +198,9 @@ fn upsert_codex_hooks_feature(existing: &str) -> String {
 
         if in_features {
             let key = trimmed.split('=').next().map(str::trim).unwrap_or("");
-            if key == "codex_hooks" {
+            if key == "hooks" {
+                hooks_line = Some(idx);
+            } else if key == "codex_hooks" {
                 codex_hooks_line = Some(idx);
             }
         }
@@ -206,21 +209,23 @@ fn upsert_codex_hooks_feature(existing: &str) -> String {
     if features_start.is_none() {
         let trimmed = normalized.trim_end_matches('\n');
         if trimmed.is_empty() {
-            return "[features]\ncodex_hooks = true\n".to_string();
+            return "[features]\nhooks = true\n".to_string();
         }
-        return format!("{trimmed}\n\n[features]\ncodex_hooks = true\n");
+        return format!("{trimmed}\n\n[features]\nhooks = true\n");
     }
 
     let mut output = Vec::with_capacity(lines.len() + 1);
     let insert_at = features_end;
     for (idx, line) in lines.iter().enumerate() {
-        if Some(idx) == codex_hooks_line {
-            output.push("codex_hooks = true".to_string());
+        if Some(idx) == hooks_line {
+            output.push("hooks = true".to_string());
+        } else if Some(idx) == codex_hooks_line {
+            // Drop the deprecated alias while still allowing insertion below.
         } else {
             output.push((*line).to_string());
         }
-        if codex_hooks_line.is_none() && idx + 1 == insert_at {
-            output.push("codex_hooks = true".to_string());
+        if hooks_line.is_none() && idx + 1 == insert_at {
+            output.push("hooks = true".to_string());
         }
     }
 
@@ -269,7 +274,12 @@ mod tests {
         assert!(codex_block_matches_current(&content));
         assert!(fs::read_to_string(&paths.config_path)
             .unwrap()
-            .contains("codex_hooks = true"));
+            .contains("hooks = true"));
+        assert_eq!(
+            hook::hook_entries_for_event_matcher(&hooks, "PreToolUse", hook::TKN_CODEX_MATCHER)
+                .len(),
+            1
+        );
         assert_eq!(
             hook::hook_entries_for_event_matcher(&hooks, "PostToolUse", hook::TKN_CODEX_MATCHER)
                 .len(),
@@ -348,7 +358,30 @@ mod tests {
         let content = fs::read_to_string(&config_path).unwrap();
         assert!(content.contains("[features]"));
         assert!(content.contains("apps = true"));
-        assert!(content.contains("codex_hooks = true"));
+        assert!(content.contains("hooks = true"));
+        assert!(!content.contains("codex_hooks"));
+        assert!(content.contains("[tools]\nweb_search = true"));
+
+        let _ = fs::remove_dir_all(repo);
+    }
+
+    #[test]
+    fn setup_codex_repo_migrates_deprecated_codex_hooks_feature() {
+        let repo =
+            env::temp_dir().join(format!("tkn-setup-codex-migrate-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        let config_path = hook::codex_config_path(&repo);
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(
+            &config_path,
+            "[features]\napps = true\ncodex_hooks = true\n\n[tools]\nweb_search = true\n",
+        )
+        .unwrap();
+
+        setup_codex_repo(&repo).unwrap();
+        let content = fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains("hooks = true"));
+        assert!(!content.contains("codex_hooks"));
         assert!(content.contains("[tools]\nweb_search = true"));
 
         let _ = fs::remove_dir_all(repo);

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 pub const CODEX_BEGIN_MARKER: &str = "<!-- tkn:begin codex -->";
 pub const CODEX_END_MARKER: &str = "<!-- tkn:end codex -->";
-pub const CODEX_TEMPLATE_VERSION: u32 = 2;
+pub const CODEX_TEMPLATE_VERSION: u32 = 3;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -172,8 +172,8 @@ pub fn codex_managed_block() -> String {
 <!-- tkn:template-version {CODEX_TEMPLATE_VERSION} -->\n\
 ## tkn Codex Workflow\n\
 \n\
-- Codex `PreToolUse` hooks cannot currently rewrite command input, so the repo instructions are the source of truth for routing commands through `tkn`.\n\
-- This repo enables a Codex `PostToolUse` hook in `.codex/hooks.json` to optimize oversized bare Bash output after a command runs.\n\
+- This repo enables Codex `PreToolUse` and `PostToolUse` hooks in `.codex/hooks.json`.\n\
+- `PreToolUse` rewrites Bash commands through `tkn auto`; `PostToolUse` optimizes oversized bare output that bypasses routing.\n\
 - Default to `tkn auto -- <command>`.\n\
 - Use `tkn exec -- <command>` for deterministic captured output.\n\
 - Use `tkn pass -- <command>` for interactive, long-lived, or streaming commands.\n\


### PR DESCRIPTION
## Summary

- route Codex PreToolUse Bash commands through `tkn auto` using `updatedInput.command`
- install and verify both Codex PreToolUse and PostToolUse hooks
- migrate Codex setup and doctor checks to canonical `features.hooks = true`
- refresh managed AGENTS.md and README guidance for current Codex hook behavior

## Validation

- `cargo test hook`
- `cargo test setup`
- `cargo test doctor`
- `cargo test`
- `cargo clippy`
- `git diff --check`
